### PR TITLE
DirectX11ライブラリの機能追加

### DIFF
--- a/src/KingdomCraft/KingdomCraft/Library/DX11Manager/DX11Manager.cpp
+++ b/src/KingdomCraft/KingdomCraft/Library/DX11Manager/DX11Manager.cpp
@@ -37,6 +37,20 @@ void DX11Manager::Release()
 	ReleaseDevice();
 }
 
+
+void DX11Manager::BeginScene()
+{
+	float ClearColor[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+
+	m_pDeviceContext->ClearRenderTargetView(m_pRenderTargetView, ClearColor);
+	m_pDeviceContext->ClearDepthStencilView(m_pDepthStencilView, D3D11_CLEAR_DEPTH, 1.0f, 0);
+}
+
+void DX11Manager::EndScene()
+{
+	m_pDXGISwapChain->Present(1, 0);
+}
+
 ID3D11Device* DX11Manager::GetDevice()
 {
 	return m_pDevice;

--- a/src/KingdomCraft/KingdomCraft/Library/DX11Manager/DX11Manager.h
+++ b/src/KingdomCraft/KingdomCraft/Library/DX11Manager/DX11Manager.h
@@ -14,6 +14,9 @@ public:
 	bool Init(HWND _hWnd);
 	void Release();
 
+	void BeginScene();
+	void EndScene();
+
 	ID3D11Device* GetDevice();
 	ID3D11DeviceContext* GetDeviceContext();
 


### PR DESCRIPTION
**追加機能**
- DirectX11の描画を行う上で必要なオブジェクトの生成処理と解放処理
- DeviceとDeviceContextの取得関数
