### PR TITLE
Dx11Managerクラスの初期化部分の修正

### DIFF
--- a/src/KingdomCraft/KingdomCraft/Library/DX11Manager/DX11Manager.cpp
+++ b/src/KingdomCraft/KingdomCraft/Library/DX11Manager/DX11Manager.cpp
@@ -3,25 +3,40 @@
 
 DX11Manager* DX11Manager::m_pDX11Manager = NULL;
 
-DX11Manager::DX11Manager(HWND _hWnd)
+DX11Manager::DX11Manager()
+{
+	
+}
+
+DX11Manager::~DX11Manager()
+{
+	
+}
+
+bool DX11Manager::Init(HWND _hWnd)
 {
 	m_hWnd = _hWnd;
 	GetWindowRect(m_hWnd, &m_WindowRect);
 
-	if (InitDevice())
+	if (!InitDevice())
 	{
-		if (InitDisplay())
-		{
-
-		}
-		else
-		{
-			ReleaseDevice();
-		}
+		MessageBox(m_hWnd, "InitDeviceに失敗しました", "エラー", MB_ICONSTOP);
+		return false;
 	}
+
+	if (!InitDisplay())
+	{
+		MessageBox(m_hWnd, "InitDisplayに失敗しました", "エラー", MB_ICONSTOP);
+		ReleaseDevice();
+		return false;
+	}
+
+	OutputDebugString("DX11Managerの初期化に成功\n");
+
+	return true;
 }
 
-DX11Manager::~DX11Manager()
+void DX11Manager::Release()
 {
 	ReleaseDisplay();
 	ReleaseDevice();

--- a/src/KingdomCraft/KingdomCraft/Library/DX11Manager/DX11Manager.h
+++ b/src/KingdomCraft/KingdomCraft/Library/DX11Manager/DX11Manager.h
@@ -10,11 +10,11 @@ class DX11Manager
 public:
 	~DX11Manager();
 
-	static void Create(HWND _hWnd)
+	static void Create()
 	{
 		if (m_pDX11Manager == NULL)
 		{
-			m_pDX11Manager = new DX11Manager(_hWnd);
+			m_pDX11Manager = new DX11Manager();
 		}
 	}
 
@@ -29,6 +29,8 @@ public:
 		m_pDX11Manager = NULL;
 	}
 
+	bool Init(HWND _hWnd);
+	void Release();
 	void BeginScene();
 	void EndScene();
 	
@@ -36,7 +38,7 @@ public:
 	ID3D11DeviceContext* GetDeviceContext();
 
 private:
-	DX11Manager(HWND _hWnd);
+	DX11Manager();
 	bool InitDevice();
 	bool InitDisplay();
 	void ReleaseDevice();


### PR DESCRIPTION
Dx11Managerクラスの初期化がコンストラクタでされていたので、初期化関数を作成して、そこでするようにする
