### PR TITLE
SceneManager配下のリファクタリングと修正

### DIFF
--- a/src/KingdomCraft/KingdomCraft/Main/SceneManager/Scene/GameScene/GameScene.cpp
+++ b/src/KingdomCraft/KingdomCraft/Main/SceneManager/Scene/GameScene/GameScene.cpp
@@ -4,20 +4,35 @@
  * @author kotani
  */
 #include "GameScene.h"
-#include "..//Scene.h"
+#include "DX11Manager\DX11Manager.h"
+#include "TextureManager\TextureManager.h"
+#include "ShaderManager\ShaderManager.h"
+#include "DSoundManager\DSoundManager.h"
+#include "FbxFileManager\FbxFileManager.h"
+
 
 GameScene::GameScene() :
-Scene(SceneID::SCENE_GAME)
+Scene(SCENE_GAME)
 {
+	TextureManager::Create(DX11Manager::GetInstance()->GetDevice());
+	ShaderManager::Create(DX11Manager::GetInstance()->GetDevice());
+	DSoundManager::Create(DX11Manager::GetInstance()->GetWindowHandle());
+	FbxFileManager::Create(DX11Manager::GetInstance()->GetDevice(), DX11Manager::GetInstance()->GetDeviceContext());
+	FbxFileManager::GetInstance()->Init();
 }
 
 GameScene::~GameScene()
 {
+	FbxFileManager::GetInstance()->Release();
+	FbxFileManager::Delete();
+	DSoundManager::Destroy();
+	ShaderManager::Delete();
+	TextureManager::Delete();
 }
 
-SceneID GameScene::Control()
+Scene::SceneID GameScene::Control()
 {
-	return m_sceneID;
+	return m_SceneID;
 }
 
 void GameScene::Draw()

--- a/src/KingdomCraft/KingdomCraft/Main/SceneManager/Scene/GameScene/GameScene.h
+++ b/src/KingdomCraft/KingdomCraft/Main/SceneManager/Scene/GameScene/GameScene.h
@@ -5,7 +5,7 @@
  */
 #ifndef GAMESCENE_H
 #define GAMESCENE_H
-#include "..//Scene.h"
+#include "..\Scene.h"
 
 /**
  * ゲームシーンを管理するクラス
@@ -33,6 +33,10 @@ public:
 	 * GameSceneの描画関数
 	 */
 	virtual void Draw();
+
+private:
+	GameScene(const GameScene&);
+	void operator=(const GameScene&);
 
 };
 

--- a/src/KingdomCraft/KingdomCraft/Main/SceneManager/Scene/Scene.cpp
+++ b/src/KingdomCraft/KingdomCraft/Main/SceneManager/Scene/Scene.cpp
@@ -6,11 +6,12 @@
 #include "Scene.h"
 
 Scene::Scene(SceneID _sceneID) :
-m_sceneID(_sceneID)
+m_SceneID(_sceneID)
 {
-}
 
+}
 
 Scene::~Scene()
 {
+
 }

--- a/src/KingdomCraft/KingdomCraft/Main/SceneManager/Scene/Scene.h
+++ b/src/KingdomCraft/KingdomCraft/Main/SceneManager/Scene/Scene.h
@@ -5,21 +5,7 @@
  */
 #ifndef SCENE_H
 #define SCENE_H
-
-/**
- * シーンのID
- */
-enum SceneID
-{
-	SCENE_LOGO,			//!< ロゴシーンID
-	SCENE_OPENING,		//!< オープニングシーンID
-	SCENE_TITLE,		//!< タイトルシーンID
-	SCENE_GAME,			//!< ゲームシーンID
-	SCENE_CONTINUE_GAME,//!< 続きからゲームを始めるときのシーンID
-	SCENE_RESULT,		//!< リザルトシーンID
-	SCENE_ENDING,		//!< エンディングシーンID
-	FIN					//!< シーン終了のID
-};
+#include<Windows.h>
 
 /**
  * シーンクラス
@@ -28,8 +14,25 @@ class Scene
 {
 public:
 	/**
+	 * シーンのID
+	 */
+	enum SceneID
+	{
+		SCENE_LOGO,			//!< ロゴシーンID
+		SCENE_OPENING,		//!< オープニングシーンID
+		SCENE_TITLE,		//!< タイトルシーンID
+		SCENE_GAME,			//!< ゲームシーンID
+		SCENE_CONTINUE_GAME,//!< 続きからゲームを始めるときのシーンID
+		SCENE_RESULT,		//!< リザルトシーンID
+		SCENE_ENDING,		//!< エンディングシーンID
+		FIN					//!< シーン終了のID
+	};
+
+	/**
 	 * Sceneクラスのコンストラクタ
-	 * @param[in] _sceneID SceneのID
+	 * @param[in] _sceneID 作成したSceneのID
+	 * @param[in] _hWnd Sceneを動作させるウィンドウのハンドル
+	 *
 	 */
 	Scene(SceneID _sceneID);
 
@@ -39,27 +42,28 @@ public:
 	virtual ~Scene();
 
 	/**
-	 * Sceneの描画関数
-	 */
-	virtual void Draw() = 0;
-
-	/**
 	 * Sceneの制御関数
 	 * @return 遷移先のシーンID
 	 */
 	virtual SceneID Control() = 0;
 
 	/**
+	 * Sceneの描画関数
+	 */
+	virtual void Draw() = 0;
+
+	/**
 	 * Sceneクラスのデストラクタ
 	 * @return シーンのID
 	 */
-	SceneID GetSceneID()
+	inline SceneID GetSceneID()
 	{ 
-		return m_sceneID; 
+		return m_SceneID;
 	}
 
 protected:
-	SceneID m_sceneID;
+	SceneID m_SceneID;
 
 };
+
 #endif

--- a/src/KingdomCraft/KingdomCraft/Main/SceneManager/Scene/TitleScene/TitleScene.cpp
+++ b/src/KingdomCraft/KingdomCraft/Main/SceneManager/Scene/TitleScene/TitleScene.cpp
@@ -11,15 +11,19 @@
 #include "InputDeviceManager\InputDeviceManager.h"
 #include "TextureManager\TextureManager.h"
 #include "ShaderManager\ShaderManager.h"
+#include "DSoundManager\DSoundManager.h"
 #include "FbxFileManager\FbxFileManager.h"
 
 
 TitleScene::TitleScene() :
-Scene(SceneID::SCENE_TITLE),
-m_pTitleBackground(new TitleBackground()),
-m_pTitleLogo(new TitleLogo()),
-m_pTitleMenu(new TitleMenu())
+Scene(SCENE_TITLE)
 {
+	TextureManager::Create(DX11Manager::GetInstance()->GetDevice());
+	DSoundManager::Create(DX11Manager::GetInstance()->GetWindowHandle());
+
+	m_pTitleBackground = new TitleBackground();
+	m_pTitleLogo = new TitleLogo();
+	m_pTitleMenu = new TitleMenu();
 }
 
 TitleScene::~TitleScene()
@@ -27,17 +31,16 @@ TitleScene::~TitleScene()
 	delete m_pTitleMenu;
 	delete m_pTitleLogo;
 	delete m_pTitleBackground;
-	TextureManager::GetInstance()->ClearBuffer();
-	ShaderManager::GetInstance()->ClearPixelShaderBuffer();
-	ShaderManager::GetInstance()->ClearVertexShaderBuffer();
-	FbxFileManager::GetInstance()->ClearBuffer();
+
+	DSoundManager::Destroy();
+	TextureManager::Delete();
 }
 
-SceneID TitleScene::Control()
+Scene::SceneID TitleScene::Control()
 {
 	InputDeviceManager::GetInstance()->MouseUpdate();
 
-	SceneID NextSceneID = m_sceneID;
+	SceneID NextSceneID = m_SceneID;
 
 	m_pTitleBackground->Control();
 	m_pTitleLogo->Control();

--- a/src/KingdomCraft/KingdomCraft/Main/SceneManager/SceneFactory/SceneFactory.cpp
+++ b/src/KingdomCraft/KingdomCraft/Main/SceneManager/SceneFactory/SceneFactory.cpp
@@ -4,33 +4,45 @@
  * @author kotani
  */
 #include "SceneFactory.h"
-#include "..//Scene//GameScene//GameScene.h"
-#include "..//Scene//TitleScene//TitleScene.h"
+#include "..\Scene\GameScene\GameScene.h"
+#include "..\Scene\TitleScene\TitleScene.h"
 #include <Windows.h>
-Scene* SceneFactory::CreateScene(SceneID _sceneID)
+
+
+SceneFactory::SceneFactory()
+{
+
+}
+
+SceneFactory::~SceneFactory()
+{
+
+}
+
+Scene* SceneFactory::CreateScene(Scene::SceneID _sceneID)
 {
 	Scene* pScene = NULL;
 
 	switch (_sceneID)
 	{
-	case SCENE_LOGO:
+	case Scene::SCENE_LOGO:
 		break;
-	case SCENE_OPENING:
+	case Scene::SCENE_OPENING:
 		break;
-	case SCENE_TITLE:
+	case Scene::SCENE_TITLE:
 		pScene = new TitleScene();
 		break;
-	case SCENE_GAME:
+	case Scene::SCENE_GAME:
 		pScene = new GameScene();
 		break;
-	case SCENE_CONTINUE_GAME:
+	case Scene::SCENE_CONTINUE_GAME:
 		pScene = new GameScene();
 		break;
-	case SCENE_RESULT:
+	case Scene::SCENE_RESULT:
 		break;
-	case SCENE_ENDING:
+	case Scene::SCENE_ENDING:
 		break;
-	case FIN:
+	case Scene::FIN:
 		break;
 	default:
 		break;

--- a/src/KingdomCraft/KingdomCraft/Main/SceneManager/SceneFactory/SceneFactory.h
+++ b/src/KingdomCraft/KingdomCraft/Main/SceneManager/SceneFactory/SceneFactory.h
@@ -5,9 +5,7 @@
  */
 #ifndef SCENEFACTORY_H
 #define SCENEFACTORY_H
-
-class Scene;
-enum SceneID;
+#include "..\Scene\Scene.h"
 
 /**
  * Sceneの生成管理するクラス
@@ -16,25 +14,23 @@ class SceneFactory
 {
 public:
 	/**
-	 * SceneFactoryのコンストラクタ
-	 */
-	SceneFactory()
-	{
-	}
-	
-	/**
-	 * SceneFactoryのデストラクタ
-	 */
-	~SceneFactory()
-	{
-	}
-
-	/**
 	 * シーンクラスの生成
 	 * @param _sceneID 生成するクラスのシーンID
 	 * @return シーンクラスのインスタンス
 	 */
-	Scene* CreateScene(SceneID _sceneID);
+	static Scene* CreateScene(Scene::SceneID _sceneID);
+
+private:
+	/**
+	 * SceneFactoryのコンストラクタ
+	 */
+	SceneFactory();
+
+	/**
+	 * SceneFactoryのデストラクタ
+	 */
+	~SceneFactory();
 
 };
+
 #endif

--- a/src/KingdomCraft/KingdomCraft/Main/SceneManager/SceneManager.cpp
+++ b/src/KingdomCraft/KingdomCraft/Main/SceneManager/SceneManager.cpp
@@ -13,108 +13,75 @@
 #include "DSoundManager\DSoundManager.h"
 #include "FbxFileManager\FbxFileManager.h"
 
+
 SceneManager::SceneManager(HWND _hwnd) :
 m_pScene(NULL),
-m_sceneState(SCENE_CREATE),
-m_nextSceneID(SceneID::SCENE_TITLE),
-m_end(false),
-m_hWnd(_hwnd)
+m_State(SCENE_CREATE),
+m_NextSceneID(Scene::SCENE_TITLE),
+m_hWnd(_hwnd),
+m_IsGameEnd(false)
 {
 	DX11Manager::Create();
 	DX11Manager::GetInstance()->Init(m_hWnd);
-
 	InputDeviceManager::Create();
 	InputDeviceManager::GetInstance()->Init(m_hWnd);
 	InputDeviceManager::GetInstance()->CreateKeyDevice();
 	InputDeviceManager::GetInstance()->CreateMouseDevice();
-
-	TextureManager::Create(DX11Manager::GetInstance()->GetDevice());
-
-	ShaderManager::Create(DX11Manager::GetInstance()->GetDevice());
-
-	DSoundManager::Create(m_hWnd);
-
-	FbxFileManager::Create(DX11Manager::GetInstance()->GetDevice(), DX11Manager::GetInstance()->GetDeviceContext());
-	FbxFileManager::GetInstance()->Init();
-
-	m_pSceneFactory = new SceneFactory();
 }
 
 SceneManager::~SceneManager()
 {
 	delete m_pScene;
-	delete m_pSceneFactory;
-
-	FbxFileManager::GetInstance()->Release();
-	FbxFileManager::Delete();
-
-	DSoundManager::Destroy();
-	
-	ShaderManager::Delete();
-
-	TextureManager::Delete();
-
 	InputDeviceManager::GetInstance()->Release();
 	InputDeviceManager::Delete();
-
 	DX11Manager::GetInstance()->Release();
 	DX11Manager::Delete();
-}
-
-void SceneManager::Control()
-{
-	SceneID currentSceneID;
-
-	if (m_pScene == NULL)
-	{
-		currentSceneID = m_nextSceneID;
-		if (currentSceneID == FIN)
-		{
-			m_end = true;
-			return;
-		}
-	}
-	else
-	{
-		currentSceneID = m_pScene->GetSceneID();
-	}
-
-	switch (m_sceneState) 
-	{
-	case SCENE_CREATE:
-		m_pScene = m_pSceneFactory->CreateScene(currentSceneID);
-		m_sceneState = SCENE_PROC;
-		break;
-	case SCENE_PROC:
-		m_nextSceneID = m_pScene->Control();
-		if (m_nextSceneID != currentSceneID)
-		{
-			m_sceneState = SCENE_RELEASE;
-		}
-		break;
-	case SCENE_RELEASE:
-		delete m_pScene;
-		m_pScene = NULL;
-		m_sceneState = SCENE_CREATE;
-		break;
-	}
-}
-
-void SceneManager::Draw()
-{
-	if (m_sceneState != SCENE_PROC)
-	{
-		return;
-	}
-	if (!m_pScene == NULL)
-	{
-		m_pScene->Draw();
-	}
 }
 
 bool SceneManager::Run()
 {
 	Control();
 	Draw();
-	return m_end;
+
+	return m_IsGameEnd;
 }
+
+void SceneManager::Control()
+{
+	Scene::SceneID CurrentSceneID;
+
+	switch (m_State)
+	{
+	case SCENE_CREATE:
+		if (m_NextSceneID == Scene::FIN)
+		{
+			m_IsGameEnd = true;
+			return;
+		}
+		m_pScene = SceneFactory::CreateScene(m_NextSceneID);
+		m_State = SCENE_PROC;
+		break;
+	case SCENE_PROC:
+		CurrentSceneID = m_pScene->GetSceneID();
+		m_NextSceneID = m_pScene->Control();
+		if (m_NextSceneID != CurrentSceneID)
+		{
+			m_State = SCENE_RELEASE;
+		}
+		break;
+	case SCENE_RELEASE:
+		delete m_pScene;
+		m_pScene = NULL;
+		m_State = SCENE_CREATE;
+		break;
+	}
+}
+
+void SceneManager::Draw()
+{
+	if (m_State == SCENE_PROC)
+	{
+		m_pScene->Draw();
+	}
+}
+

--- a/src/KingdomCraft/KingdomCraft/Main/SceneManager/SceneManager.h
+++ b/src/KingdomCraft/KingdomCraft/Main/SceneManager/SceneManager.h
@@ -6,10 +6,7 @@
 #ifndef SCENEMANAGER_H
 #define SCENEMANAGER_H
 #include <Windows.h>
-
-class Scene;
-class SceneFactory;
-enum SceneID;
+#include "Scene\Scene.h"
 
 /**
  * シーンを管理するクラス
@@ -38,22 +35,29 @@ private:
 	/**
 	 * SceneManagerの状態
 	 */
-	enum SceneState
+	enum State
 	{
 		SCENE_CREATE,	//!< シーンの生成状態
 		SCENE_PROC,		//!< シーンの処理状態		
 		SCENE_RELEASE	//!< シーンの解放状態
 	};
 
+	/**
+	 * SceneManagerクラスの制御関数
+	 */
 	void Control();
+
+	/**
+	 * SceneManagerクラスの描画関数
+	 */
 	void Draw();
 
-	SceneFactory* m_pSceneFactory;
-	Scene*		  m_pScene;
-	SceneState    m_sceneState;
-	SceneID		  m_nextSceneID;
-	HWND		  m_hWnd;
-	bool		  m_end;
+	Scene*			m_pScene;
+	State			m_State;
+	Scene::SceneID	m_NextSceneID;
+	HWND			m_hWnd;
+	bool			m_IsGameEnd;
 
 };
+
 #endif


### PR DESCRIPTION
**修正内容**
- 一部のライブラリ系オブジェクトはシーン内で生成するようにした。
- 変数名の修正
- enumなどはクラス内で定義するようにした。
- SceneFactoryクラスにモノステートパターンを適用した
- ファイルパス関係は\で統一した

issue #152