### PR TITLE
Vertex2Dのアルファ値の計算方法の変更

### DIFF
--- a/src/KingdomCraft/KingdomCraft/Library/Vertex2D/Effect/Vertex2D.fx
+++ b/src/KingdomCraft/KingdomCraft/Library/Vertex2D/Effect/Vertex2D.fx
@@ -42,6 +42,6 @@ float4 PS(PS_INPUT Input) : SV_Target
 {
 	PS_INPUT Out;
 	Out.Color = Texture.Sample(Sampler, Input.UV);
-	Out.Color.a = g_Alpha.a;
+	Out.Color.a *= g_Alpha.a;
 	return Out.Color;
 }


### PR DESCRIPTION
**修正内容**
* アルファ値を代入してテクスチャ側のアルファ値が消えてしまっていたので計算方法を変更した

issue #197