### PR TITLE
DebugFontクラスの解放漏れを修正

### DIFF
--- a/src/KingdomCraft/KingdomCraft/Library/DebugFont/DebugFont.cpp
+++ b/src/KingdomCraft/KingdomCraft/Library/DebugFont/DebugFont.cpp
@@ -112,6 +112,7 @@ bool DebugFont::Init(HWND _hWnd)
 
 void DebugFont::Release()
 {
+	ReleaseFont();
 	ReleaseDepthStencilState();
 	ReleaseBlendState();
 	ReleaseSamplerState();
@@ -549,5 +550,14 @@ void DebugFont::ReleaseDepthStencilState()
 	{
 		m_pDepthStencilState->Release();
 		m_pDepthStencilState = NULL;
+	}
+}
+
+void DebugFont::ReleaseFont()
+{
+	if (m_pVertexBuffer != NULL)
+	{
+		m_pVertexBuffer->Release();
+		m_pVertexBuffer = NULL;
 	}
 }

--- a/src/KingdomCraft/KingdomCraft/Library/DebugFont/DebugFont.h
+++ b/src/KingdomCraft/KingdomCraft/Library/DebugFont/DebugFont.h
@@ -163,6 +163,11 @@ private:
 	 */
 	void ReleaseDepthStencilState();
 
+	/**
+	 * フォントの頂点バッファ解放関数
+	 */
+	void ReleaseFont();
+
 	static const float m_DebugFontTu;
 	static const int m_SpaceAsciiCode;
 	ID3D11Device* const			m_pDevice;


### PR DESCRIPTION
**修正内容**
- DebugFontクラスの頂点バッファを解放するよう修正した

issue #224 